### PR TITLE
sophia: logging made manual

### DIFF
--- a/apps/sophia-agent/package.json
+++ b/apps/sophia-agent/package.json
@@ -19,8 +19,7 @@
 		"@iqai/agent": "^0.2.1",
 		"@iqai/plugin-atp": "^0.4.3",
 		"@iqai/plugin-heartbeat": "^0.3.1",
-		"@iqai/plugin-sequencer": "^0.2.2",
-		"@iqai/plugin-wiki": "^0.1.0",
+		"@iqai/plugin-wiki": "^0.1.1",
 		"dotenv": "^16.4.7",
 		"sharp": "^0.33.5"
 	},

--- a/apps/sophia-agent/src/index.ts
+++ b/apps/sophia-agent/src/index.ts
@@ -5,13 +5,13 @@ import createHeartbeatPlugin from "@iqai/plugin-heartbeat";
 import createWikiPlugin from "@iqai/plugin-wiki";
 import { SophiaCharacter } from "./character.ts";
 import createAtpPlugin from "@iqai/plugin-atp";
-import createSequencerPlugin from "@iqai/plugin-sequencer";
-import { elizaLogger } from "@elizaos/core";
+import { elizaLogger, type IAgentRuntime } from "@elizaos/core";
 import { DirectClientInterface } from "@elizaos/client-direct";
+import { processWikiActivity } from "./utils.ts";
+
 async function main() {
 	// Initialize plugins
 	const pluginWiki = await createWikiPlugin();
-	const sequencer = await createSequencerPlugin();
 	const pluginAtp = await createAtpPlugin({
 		apiKey: process.env.ATP_API_KEY as string,
 	});
@@ -24,62 +24,47 @@ async function main() {
 				},
 			],
 			period: "*/20 * * * *",
-			input: `
-				GO THROUGH SEQUENCER AND FOLLOW THE BELOW INSTRUCTIONS.
-				Step-1. Get all wiki activities by user 0x8AF7a19a26d8FBC48dEfB35AEfb15Ec8c407f889 in the past 20 minutes.
-				Step-2. If any new wiki activity is found, generate a short announcement. Each announcement should be unique and slightly different in structure or style—avoid using the same template repeatedly. Vary greetings, sentence order, and phrasing to keep announcements fresh.
-					For created wikis, the announcement must:
-					- Clearly mention the wiki title and a brief summary (can be reworded, but must convey the main idea).
-					- Include text indicating this is a newly created wiki.
-					- Always end with the wiki link (never truncated or removed).
-					- Be under 280 characters.
-					- Not use markdown formatting.
-
-					For edited wikis, the announcement must:
-					- Clearly mention the wiki title and what was updated.
-					- Include details about the changes (words changed, sections modified) when available.
-					- Always end with the wiki link.
-					- Be under 280 characters.
-					- Not use markdown formatting.
-
-					Examples for created wikis:
-						1. New wiki published: Boxcat – a meme universe where you play, earn, and have fun. \n
-							 🔗 Transaction: https://polygonscan.com/tx/0xcf46f119878f88ffbdb74b3c6c2d2be8b79ec2b1381ea6388b4ab70ed733d2d9 \n
-							 🔗 Read more: https://iq.wiki/wiki/boxcat \n
-						2. Just created: Boxcat wiki! Dive into the world of meme-powered rewards and interactive stories. \n
-							 🔗 Transaction: https://polygonscan.com/tx/0xcf46f119878f88ffbdb74b3c6c2d2be8b79ec2b1381ea6388b4ab70ed733d2d9 \n
-							 🔗 Details: https://iq.wiki/wiki/boxcat \n
-
-					Examples for edited wikis:
-						1. Wiki updated: Boxcat – with 52 new words and revisions to content and tags sections. \n
-							 🔗 Transaction: https://polygonscan.com/tx/0xcf46f119878f88ffbdb74b3c6c2d2be8b79ec2b1381ea6388b4ab70ed733d2d9 \n
-							 🔗 Read more: https://iq.wiki/revision/866f337b-092c-480b-8f20-cbe521989d3b \n
-						2. Fresh updates to Boxcat wiki! Changes include new content sections and improved descriptions. \n
-							 🔗 Transaction: https://polygonscan.com/tx/0xcf46f119878f88ffbdb74b3c6c2d2be8b79ec2b1381ea6388b4ab70ed733d2d9 \n
-							 🔗 Details: https://iq.wiki/revision/866f337b-092c-480b-8f20-cbe521989d3b \n
-				Step-3. Post the neatly worded announcement from step-2 (excluding the txn-link in the content) as a new log on the atp site to the agent ${process.env.AGENT_TOKEN_CONTRACT} with the provided polygonscan link as transaction link and chainId as 137.
-					STRUCTURE THE COMMAND AS:
-						Add log for the agent ${process.env.AGENT_TOKEN_CONTRACT} with the content:
-						{INSERT THE ANNOUNCEMENT HERE}
-						with transaction hash: {INSERT THE TRANSACTION HASH HERE}
-						with chainId: 137
-					IT IS IMPORTANT YOU MENTION THE TRANSACTION HASH AND CHAIN ID (ALWAYS 137) IN THE COMMAND.
-
-					An example execution command to the tool would be:
-					 Add log for the agent ${process.env.AGENT_TOKEN_CONTRACT} with the content as:
-					 New wiki published: Boxcat – a meme universe where you play, earn, and have fun. Read more: https://iq.wiki/wiki/boxcat
-
-					 with transaction hash: 0xcf46f119878f88ffbdb74b3c6c2d2be8b79ec2b1381ea6388b4ab70ed733d2d9
-					 with chainId: 137
-				Step-4. Return the announcement generated in step-2 finally.
-				DO NOT HALLUCINATE AND ONLY RETURN THE ANNOUNCEMENT GENERATED IN STEP-2 CONTAINING THE WIKI LINK AND TXN LINK
-			`,
+			input:
+				"Get all wiki activities by user 0x8AF7a19a26d8FBC48dEfB35AEfb15Ec8c407f889 in the past 20 minutes.",
+			onlyFinalOutput: true,
 			shouldPost: (response: string) => {
 				elizaLogger.info("response: ", response);
-				return response.includes("https://iq.wiki/wiki/");
+				return response.includes("https://iq.wiki");
+			},
+			formatResponse: async (response: string, runtime: IAgentRuntime) => {
+				const wikiPattern = /📜 Wiki (Created|Edited)[\s\S]*?(?=📜 Wiki|\Z)/g;
+				const wikiActivities = response.match(wikiPattern) || [];
+
+				if (wikiActivities.length === 0) {
+					if (
+						response.includes("Wiki") &&
+						response.includes("Source: https://iq.wiki")
+					) {
+						await processWikiActivity(response, runtime);
+					}
+					return response;
+				}
+
+				elizaLogger.info(
+					`Found ${wikiActivities.length} wiki activities to process`,
+				);
+
+				// Process each wiki activity in sequence
+				for (const activity of wikiActivities) {
+					try {
+						await processWikiActivity(activity, runtime);
+					} catch (error) {
+						elizaLogger.error(
+							`Error processing wiki activity: ${error instanceof Error ? error.message : String(error)}`,
+						);
+					}
+				}
+
+				return response;
 			},
 		},
 	]);
+
 	// Build agent using builder pattern
 	const agent = new AgentBuilder()
 		.withDatabase(SqliteAdapter)
@@ -88,7 +73,7 @@ async function main() {
 			ModelProviderName.OPENAI,
 			process.env.OPENAI_API_KEY as string,
 		)
-		.withPlugins([pluginWiki, heartbeat, pluginAtp, sequencer])
+		.withPlugins([pluginWiki, heartbeat, pluginAtp])
 		.withCharacter(SophiaCharacter)
 		.build();
 

--- a/apps/sophia-agent/src/utils.ts
+++ b/apps/sophia-agent/src/utils.ts
@@ -1,0 +1,145 @@
+import {
+	elizaLogger,
+	type IAgentRuntime,
+	getEmbeddingZeroVector,
+	type Memory,
+	stringToUuid,
+	generateText,
+	ModelClass,
+} from "@elizaos/core";
+
+/**
+ * Processes a single wiki activity
+ */
+export async function processWikiActivity(
+	activity: string,
+	runtime: IAgentRuntime,
+): Promise<void> {
+	try {
+		// Extract title, transaction hash and source URL
+		const titleMatch = activity.match(/- Title: (.*?)(?=\r?\n|$)/m);
+		const title = titleMatch?.[1]?.trim() || "Unknown Wiki";
+		const isCreated = activity.includes("Created:");
+		const txnMatch = activity.match(
+			/Transaction: https:\/\/polygonscan\.com\/tx\/(0x[a-fA-F0-9]+)/,
+		);
+		const txnHash = txnMatch?.[1] || "";
+		const sourceMatch = activity.match(
+			/Source: (https:\/\/iq\.wiki\/.*?)(?=\r?\n|$)/m,
+		);
+		const sourceUrl = sourceMatch?.[1]?.trim() || "";
+
+		// Skip if missing critical data
+		if (!txnHash || !sourceUrl) {
+			elizaLogger.error(`Missing transaction hash or source URL for ${title}`);
+			return;
+		}
+
+		elizaLogger.info(
+			`Processing wiki: ${title} (${isCreated ? "created" : "edited"})`,
+		);
+
+		// Extract relevant details for the announcement
+		const summary = activity.includes("Summary:")
+			? activity.match(/- Summary: (.*?)(?=\r?\n|$)/m)?.[1]?.trim() || ""
+			: "";
+
+		const changes =
+			!isCreated && activity.includes("Changes:")
+				? activity.match(/- Changes: (.*?)(?=\r?\n|$)/m)?.[1]?.trim() || ""
+				: "";
+
+		const sections =
+			!isCreated && activity.includes("Modified sections:")
+				? activity
+						.match(/- Modified sections: (.*?)(?=\r?\n|$)/m)?.[1]
+						?.trim() || ""
+				: "";
+
+		// Create prompt context for the announcement
+		const promptContext = `
+			Create a concise announcement (max 150 characters) for a wiki that was ${isCreated ? "created" : "edited"}.
+
+			Wiki details:
+			- Title: ${title}
+			${summary ? `- Summary: ${summary}` : ""}
+			${changes ? `- Changes: ${changes}` : ""}
+			${sections ? `- Modified sections: ${sections}` : ""}
+
+			Requirements:
+			- Be creative and conversational in tone
+			- For created wikis, mention this is a new wiki
+			- For edited wikis, mention what was updated
+			- Keep it under 150 characters
+			- Do not include markdown formatting
+			- Do not include the transaction link
+			- End with "Read more: <link>" where the link is ${isCreated ? sourceUrl : sourceUrl.replace("/wiki/", "/revision/")}
+
+			Format your response as a single paragraph with no prefix or additional text.
+		`;
+
+		// Generate the announcement
+		const announcement = await generateText({
+			runtime,
+			context: promptContext,
+			modelClass: ModelClass.MEDIUM,
+		});
+
+		// Ensure announcement is not too long
+		const trimmedAnnouncement =
+			announcement.length > 180
+				? `${announcement.substring(0, 177)}...`
+				: announcement;
+
+		elizaLogger.info(
+			`Generated announcement for ${title}: ${trimmedAnnouncement}`,
+		);
+
+		// Post to ATP
+		await postToAtp(runtime, trimmedAnnouncement, txnHash);
+	} catch (error) {
+		throw new Error(
+			`Failed to process wiki activity: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+/**
+ * Helper function to post announcements to the ATP log
+ */
+async function postToAtp(
+	runtime: IAgentRuntime,
+	content: string,
+	txnHash: string,
+): Promise<void> {
+	// Call ATP_ADD_AGENT_LOG action
+	const addLogAction = runtime.actions.find(
+		(a) => a.name === "ATP_ADD_AGENT_LOG",
+	);
+
+	if (!addLogAction) {
+		elizaLogger.info("ATP_ADD_AGENT_LOG action not found");
+		return;
+	}
+
+	// Create memory with IDs that match required format
+	const memory: Memory = {
+		userId: stringToUuid("sophia-agent"),
+		agentId: runtime.agentId,
+		content: {
+			text: `
+				Add log for the agent ${process.env.AGENT_TOKEN_CONTRACT} with the content:
+				${content}
+				with transaction hash: ${txnHash}
+				with chainId: 137
+			`,
+			action: "ATP_ADD_AGENT_LOG",
+		},
+		roomId: stringToUuid("sophia-room"),
+		embedding: getEmbeddingZeroVector(),
+	};
+
+	await runtime.messageManager.createMemory(memory);
+	await addLogAction.handler(runtime, memory);
+	elizaLogger.info("Successfully posted to ATP");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,12 +407,9 @@ importers:
       '@iqai/plugin-heartbeat':
         specifier: ^0.3.1
         version: 0.3.1(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1)
-      '@iqai/plugin-sequencer':
-        specifier: ^0.2.2
-        version: 0.2.2(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1)
       '@iqai/plugin-wiki':
-        specifier: ^0.1.0
-        version: 0.1.0(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1)
+        specifier: ^0.1.1
+        version: 0.1.1(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1)
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -5530,49 +5527,8 @@ packages:
       - yaml
     dev: false
 
-  /@iqai/plugin-sequencer@0.2.2(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1):
-    resolution: {integrity: sha512-FdyWkPvX80/KKztIEa9ZXaTYNaEpd/R30NsWrYEj6FoiuQ8pcMRLAaYtE3Va4k+ReZrlrdQGG0W4I2/W1IOoyA==}
-    dependencies:
-      '@elizaos/core': 0.25.9(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1)
-      dedent: 1.5.3
-      tsup: 8.3.6(tsx@4.19.3)(typescript@5.7.3)
-      vitest: 3.1.1(@types/node@22.14.0)(tsx@4.19.3)
-      zod: 3.24.2
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@microsoft/api-extractor'
-      - '@swc/core'
-      - '@types/debug'
-      - '@types/node'
-      - '@vitest/browser'
-      - '@vitest/ui'
-      - aws-crt
-      - babel-plugin-macros
-      - bufferutil
-      - encoding
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - postcss
-      - react
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - utf-8-validate
-      - ws
-      - yaml
-    dev: false
-
-  /@iqai/plugin-wiki@0.1.0(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1):
-    resolution: {integrity: sha512-fSr7WdfyP7KVkk6Gr3oxNTQTK9d1OmyhNDtGwiiILpT/jHteiwxA877FuLOpYaYvSTy6aCNP12GlVzA6v1VcaQ==}
+  /@iqai/plugin-wiki@0.1.1(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1):
+    resolution: {integrity: sha512-HnqfFRKAb/6sKA7cn/LEgrweBje9k1AQ0OCdl90KchtYK0yPydtA/8QaPr4brJ//gP+Vj0xVgCxqHZjh6j3rmQ==}
     dependencies:
       '@elizaos/core': 0.25.9(react@19.1.0)(tsx@4.19.3)(typescript@5.7.3)(ws@8.18.1)
       dedent: 1.5.3


### PR DESCRIPTION
## Changes

- the task given to heartbeat is sometimes not processing the logging to atp step due to several possible reasons like memory issues or llm not processing the responses properly
- i have made it so that the logging to atp part is made manual, which can process 1 or n wikis in the activities response processed by the heartbeat task handler.
- this ensures that no activity is missed in agent logs of atp site. handling/processing/response generation made more deterministic

testing responses: [DEV-SITE](https://dev.iqai.com/pending/0xDe408a409E67e1294d7978B6E9404b8e59d341a3/logs)

closes https://github.com/IQAIcom/issues/issues/226